### PR TITLE
Add ccthread to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Use the existing test patterns in this project.
 
 - [claude-code-router](https://github.com/anthropics/claude-code) - Built-in model routing for cost optimization (use haiku for simple tasks, opus for complex ones).
 - [claude-code-action](https://github.com/anthropics/claude-code-action) - GitHub Action for running Claude Code in CI/CD pipelines.
+- [ccthread](https://github.com/jakemarsh/ccthread) - Read, search, and have Claude summarize your Claude Code conversation logs from the CLI. Plugin + standalone binary.
 
 ## Skills
 


### PR DESCRIPTION
## Summary

Adds [ccthread](https://github.com/jakemarsh/ccthread) to the Plugins section.

ccthread is a Claude Code plugin (and standalone CLI) that reads conversation logs from `~/.claude/projects/` and turns each session's `.jsonl` into clean markdown — for recalling decisions, finding old threads, or summarizing rounds of work.

Install via `/plugin marketplace add jakemarsh/ccthread` or the standalone installer. Tagline: *Read, search, and have Claude summarize your Claude Code conversation logs from the CLI.*

## License

MIT.