### PR TITLE
Add Agent FM

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,6 +911,7 @@ Claude Code has a granular permission system to control what actions it can take
 - [mcpservers.org](https://mcpservers.org/) - Directory and registry of MCP servers.
 - [mcp.run](https://mcp.run/) - Run MCP servers in a secure sandbox without local installation.
 - [Smithery](https://smithery.ai/) - Package registry for MCP servers with one-click install.
+- [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local macOS companion for Claude Code and Codex sessions with live narration, Global Mix, and blocker alerts.
 
 ### Frameworks & Libraries
 


### PR DESCRIPTION
Adds Agent FM, a local/open-source macOS app for listening to Claude Code and Codex agents as they work.

It fits this list as a companion/awareness tool for developers running multiple local coding agents, with Global Mix, blocker alerts, and BYOK narration.