### PR TITLE
feat: add evc-team-relay-mcp to MCP Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ Use the existing test patterns in this project.
 - [mcp-server-notion](https://github.com/v-3/notion-server) - Notion workspace access and page management.
 - [mcp-server-raycast](https://github.com/raycast/mcp-server-raycast) - Raycast integration for macOS.
 - [mcp-server-obsidian](https://github.com/smithery-ai/mcp-obsidian) - Obsidian vault access and note management.
+- [evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp) - Collaborative Obsidian vault access via Team Relay with real-time CRDT sync.
 - [mcp-server-todoist](https://github.com/abhiz123/todoist-mcp-server) - Todoist task management integration.
 - [mcp-server-sentry](https://github.com/modelcontextprotocol/servers/tree/main/src/sentry) - Sentry error tracking integration.
 - [mcp-server-turso](https://github.com/SilasMarvin/mcp-server-turso) - Turso/LibSQL database access.


### PR DESCRIPTION
Adds [evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp) to the MCP Servers list, after the existing Obsidian entry.

MCP server for collaborative Obsidian vault access via Team Relay — real-time CRDT-based sync enabling multiple users/agents to work with shared vaults.

PyPI: pip install evc-team-relay-mcp
License: MIT | Python