### PR TITLE
feat: add TWZRD Agent Intel to Community MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ Use the existing test patterns in this project.
 - [mcp-server-sentry](https://github.com/modelcontextprotocol/servers/tree/main/src/sentry) - Sentry error tracking integration.
 - [mcp-server-turso](https://github.com/SilasMarvin/mcp-server-turso) - Turso/LibSQL database access.
 - [mcp-server-supabase](https://github.com/supabase-community/supabase-mcp) - Supabase database and auth integration.
+- [twzrd-agent-intel](https://intel.twzrd.xyz) - Trust scoring for Solana AI agents. Verify wallet identity before x402 micropayments. Zero-install: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ### MCP Resources
 


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Community MCP Servers section.

**What it does:** TWZRD Agent Intel is an MCP server that provides trust scoring for Solana AI agents. Useful when building agents that interact with other agents via x402 micropayments — verify the other agent's wallet identity before trusting them.

**Zero-install streamable-http endpoint:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Free tools: `score_agent(wallet)`, `preflight_check(wallet)`. Paid: `get_trust_receipt(wallet)` via x402.