### PR TITLE
feat: add NotFair — Claude Code skills for SEO and paid ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Use the existing test patterns in this project.
 - [claude-code-router](https://github.com/anthropics/claude-code) - Built-in model routing for cost optimization (use haiku for simple tasks, opus for complex ones).
 - [claude-code-action](https://github.com/anthropics/claude-code-action) - GitHub Action for running Claude Code in CI/CD pipelines.
 - [Hermes Tweet](https://github.com/Xquik-dev/hermes-tweet) - Xquik X/Twitter plugin with a Claude manifest and approval-gated actions.
+- [NotFair](https://github.com/nowork-studio/NotFair) - Claude Code plugin with skills for SEO, GEO, Google Ads, and Meta Ads through MCP integrations.
 
 ## Skills
 


### PR DESCRIPTION
Thanks for maintaining this list — it's a great resource for the Claude Code community.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair) to the Plugins section. It's an open-source collection of Claude Code skills (~2.9k stars) covering SEO, GEO, Google Ads, and Meta Ads. It connects to live account data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, so the skills can run real audits and make changes directly from Claude Code.

It fits naturally alongside the other plugin entries since it extends Claude Code with a specific domain (marketing/ads).

Happy to reword the description, move it to a different section, or trim it if needed. Thanks for your time!