### PR TITLE
Add ax cost monitoring tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,7 @@ export ANTHROPIC_MAX_TOKENS=100000  # Limit per session
 
 - [Anthropic Console](https://console.anthropic.com/) - Official usage dashboard and billing.
 - [LLM Cost Calculator](https://llmpricecheck.com/) - Compare Claude Code costs with other AI coding tools.
+- [ax](https://github.com/Necmttn/ax) - Local-first cost, skill, tool, and telemetry dashboard for Claude Code, Codex, OpenCode, Cursor, and Pi.
 
 ## Security & Permissions
 


### PR DESCRIPTION
## What are you adding?

Adds ax to the Cost Monitoring Tools section. It is a local-first dashboard for Claude Code/Codex session cost, tool, skill, and telemetry analysis, which is a distinct use case from billing dashboards and simple price calculators.

## Category

- [ ] Official Resources
- [ ] CLAUDE.md Template
- [ ] MCP Server
- [ ] Hook Recipe
- [ ] Workflow / Pattern
- [ ] Community Project
- [ ] Article / Blog Post
- [ ] Video / Tutorial
- [x] Other: Cost monitoring tool

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The resource is not a duplicate of an existing entry
- [x] All links are working and accessible
- [x] Each entry has a concise description (under 120 characters)
- [x] Entries are placed at the end of the correct section
- [x] Formatting matches existing entries: `- [Name](url) - Description.`
- [x] For projects: 100+ stars or unique use case
- [ ] For templates: follows the established format with all standard sections

Validation:
- `git diff --check`
- Direct link check for `https://github.com/Necmttn/ax` returned HTTP 200
- Description length checked at 104 characters
- `lychee` was not installed locally, so I verified the added link directly

---

_Generated with [ax](https://github.com/Necmttn/ax)._