### PR TITLE
Add OpenAgentRelay community project

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,6 +911,7 @@ Claude Code has a granular permission system to control what actions it can take
 - [mcpservers.org](https://mcpservers.org/) - Directory and registry of MCP servers.
 - [mcp.run](https://mcp.run/) - Run MCP servers in a secure sandbox without local installation.
 - [Smithery](https://smithery.ai/) - Package registry for MCP servers with one-click install.
+- [OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) - Expose a restricted local Claude Code or other agent command as a keyed trusted-LAN capability.
 
 ### Frameworks & Libraries
 


### PR DESCRIPTION
## What are you adding?

OpenAgentRelay, an open-source CLI that exposes a restricted local Claude Code or other agent command as a keyed capability over a trusted LAN. It has a unique team-delegation use case and keeps the publisher's source, prompts, dependencies, and credentials local.

## Category

- [ ] Official Resources
- [ ] CLAUDE.md Template
- [ ] MCP Server
- [ ] Hook Recipe
- [ ] Workflow / Pattern
- [x] Community Project
- [ ] Article / Blog Post
- [ ] Video / Tutorial
- [ ] Other

## Checklist

- [x] I have read the contribution guidelines
- [x] The resource is not a duplicate of an existing entry
- [x] The link is working and accessible
- [x] The description is clear, concise, and under 120 characters
- [x] The entry is placed at the end of Tools & Extensions
- [x] Formatting matches the existing list
- [x] The project has a unique use case despite being early-stage
