### PR TITLE
Declare least-privilege link checker permissions

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,6 +13,10 @@ on:
     - cron: "0 9 * * 1" # Every Monday at 9 AM UTC
   workflow_dispatch:
 
+# The link checker only needs read access to repository contents.
+permissions:
+  contents: read
+
 jobs:
   linkcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

- Declared explicit read-only `contents` permission for the link-check workflow.
- Documented why that permission is sufficient.

## Why

CodeQL reported that the workflow relied on implicit default token permissions. An explicit least-privilege declaration removes that ambiguity and prevents future permission broadening.

## Impact

The link checker continues to read repository files and validate Markdown links. It receives no write permission.

## Validation

- `git diff --check`
- Ruby YAML parse
