### PR TITLE
Add suede-creator-skills to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,6 +912,7 @@ Claude Code has a granular permission system to control what actions it can take
 - [mcp.run](https://mcp.run/) - Run MCP servers in a secure sandbox without local installation.
 - [Smithery](https://smithery.ai/) - Package registry for MCP servers with one-click install.
 - [OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) - Expose a restricted local Claude Code or other agent command as a keyed trusted-LAN capability.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Collection of 70 open-source Agent Skills for Claude Code and Codex, covering code review, AI evals, CI gates, design, copy, and SEO.
 
 ### Frameworks & Libraries
 

--- a/README.md
+++ b/README.md
@@ -912,7 +912,7 @@ Claude Code has a granular permission system to control what actions it can take
 - [mcp.run](https://mcp.run/) - Run MCP servers in a secure sandbox without local installation.
 - [Smithery](https://smithery.ai/) - Package registry for MCP servers with one-click install.
 - [OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) - Expose a restricted local Claude Code or other agent command as a keyed trusted-LAN capability.
-- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Collection of 70 open-source Agent Skills for Claude Code and Codex, covering code review, AI evals, CI gates, design, copy, and SEO.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Collection of 71 open-source Agent Skills for Claude Code and Codex, covering code review, AI evals, CI gates, design, copy, and SEO.
 
 ### Frameworks & Libraries
 


### PR DESCRIPTION
# Pull Request

## What are you adding?

[suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) — a collection of 71 open-source, MIT-licensed Agent Skills for Claude Code and Codex. Each skill is a `SKILL.md` the agent loads on demand, covering code review with an A–F ship grade, CI merge gates, AI evaluation suites, multi-agent orchestration, design, copy, SEO, and app release workflows.

Added as a single line under **Community Projects → Tools & Extensions**.

## Category

- [ ] Official Resources
- [ ] CLAUDE.md Template
- [ ] MCP Server
- [ ] Plugin
- [ ] Skill
- [ ] Hook Recipe
- [ ] Workflow / Pattern
- [x] Community Project
- [ ] Article / Blog Post
- [ ] Video / Tutorial
- [ ] Other

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] Formatted per CONTRIBUTING: `- [Resource Name](link) - One-line description ending with a period.`
- [x] Link verified reachable (200)
- [x] Not already present in the list
